### PR TITLE
feat: Add filtering

### DIFF
--- a/schemas/app.graphql
+++ b/schemas/app.graphql
@@ -6,7 +6,7 @@ type Query {
     page: Int!
     sortOption: SortOption
     sortOrder: SortOrder
-    filter: String
+    filter: Filter
   ): [PlayerData]
   teams: [TeamData]
 }
@@ -14,4 +14,41 @@ type Query {
 enum SortOrder {
   ASC
   DESC
+}
+
+enum FilterValue {
+  ARS
+  AVL
+  BOU
+  BHA
+  BUR
+  CHE
+  CRY
+  EVE
+  LEI
+  LIV
+  MCI
+  MUN
+  NEW
+  NOR
+  SHU
+  SOU
+  TOT
+  WAT
+  WHU
+  WOL
+  GKP
+  DEF
+  MID
+  FWD
+}
+
+enum FilterKey {
+  TEAM
+  POSITION
+}
+
+input Filter {
+  key: FilterKey
+  value: FilterValue
 }

--- a/schemas/app.graphql
+++ b/schemas/app.graphql
@@ -46,9 +46,11 @@ enum FilterValue {
 enum FilterKey {
   TEAM
   POSITION
+  VALUE
 }
 
 input Filter {
-  key: FilterKey
+  key: FilterKey!
   value: FilterValue
+  limit: Int
 }

--- a/schemas/players.graphql
+++ b/schemas/players.graphql
@@ -51,11 +51,7 @@ type PlayerData {
   assists: Int
   cleanSheets: Int
   goalsConceded: Int
-  position: PlayerPositionData
-}
-
-type PlayerPositionData {
-  id: ID!
-  singularName: String!
-  shortName: String!
+  teamCode: Int
+  position: String!
+  positionShortName: String!
 }

--- a/src/resolvers/players.js
+++ b/src/resolvers/players.js
@@ -1,8 +1,13 @@
 import sortPlayers from '../utils/sortPlayers';
+import filterPlayers from '../utils/filterPlayers';
 
 const addPosition = (players, positions) =>
   players.map(player => {
-    const newPlayer = { ...player, positionData: positions[player.element_type] };
+    const newPlayer = {
+      ...player,
+      position_short_name: positions[player.element_type].singular_name_short,
+      position: positions[player.element_type].singular_name
+    };
     return newPlayer;
   });
 
@@ -17,12 +22,18 @@ const getPlayers = data => {
   return addPosition(data.elements, positions);
 };
 
-const players = async (_, { perPage, page, sortOption, sortOrder }, { data }) => {
+const players = async (_, { perPage, page, sortOption, sortOrder, filter }, { data }) => {
   try {
+    // Get player data with positions
     const playerData = getPlayers(data);
+
+    // Apply any filters to data
+    const filteredPlayers = filterPlayers(playerData, filter);
+
+    // sort data
     const sortedData = sortOption
-      ? playerData.sort(sortPlayers(sortOption, sortOrder))
-      : playerData;
+      ? filteredPlayers.sort(sortPlayers(sortOption, sortOrder))
+      : filteredPlayers;
     const updatedPage = page - 1;
     return sortedData.slice(updatedPage * perPage, perPage * page);
   } catch (err) {

--- a/src/resolvers/typeResolvers/FilterKey.js
+++ b/src/resolvers/typeResolvers/FilterKey.js
@@ -1,6 +1,7 @@
 const FilterKey = {
   POSITION: 'position_short_name',
-  TEAM: 'team_code'
+  TEAM: 'team_code',
+  VALUE: 'now_cost'
 };
 
 export default FilterKey;

--- a/src/resolvers/typeResolvers/FilterKey.js
+++ b/src/resolvers/typeResolvers/FilterKey.js
@@ -1,0 +1,6 @@
+const FilterKey = {
+  POSITION: 'position_short_name',
+  TEAM: 'team_code'
+};
+
+export default FilterKey;

--- a/src/resolvers/typeResolvers/FilterValue.js
+++ b/src/resolvers/typeResolvers/FilterValue.js
@@ -1,0 +1,28 @@
+const FilterValue = {
+  ARS: 3,
+  AVL: 7,
+  BOU: 91,
+  BHA: 36,
+  BUR: 90,
+  CHE: 8,
+  CRY: 31,
+  EVE: 11,
+  LEI: 13,
+  LIV: 14,
+  MCI: 43,
+  MUN: 1,
+  NEW: 4,
+  NOR: 45,
+  SHU: 49,
+  SOU: 20,
+  TOT: 6,
+  WAT: 57,
+  WHU: 21,
+  WOL: 39,
+  GKP: 'GKP',
+  DEF: 'DEF',
+  MID: 'MID',
+  FWD: 'FWD'
+};
+
+export default FilterValue;

--- a/src/resolvers/typeResolvers/PlayerData.js
+++ b/src/resolvers/typeResolvers/PlayerData.js
@@ -22,7 +22,10 @@ const PlayerData = {
   averagePointsPerGame: ({ points_per_game }) => points_per_game,
   goals: ({ goals_scored }) => goals_scored,
   cleanSheets: ({ clean_sheets }) => clean_sheets,
-  goalsConceded: ({ goals_conceded }) => goals_conceded
+  goalsConceded: ({ goals_conceded }) => goals_conceded,
+  teamCode: ({ team_code }) => team_code,
+  position: ({ position }) => position,
+  positionShortName: ({ position_short_name }) => position_short_name
 };
 
 export default PlayerData;

--- a/src/resolvers/typeResolvers/PlayerPositionData.js
+++ b/src/resolvers/typeResolvers/PlayerPositionData.js
@@ -1,8 +1,0 @@
-/* eslint-disable */
-const PlayerPositionData = {
-  id: ({ id }) => id,
-  singularName: ({ singular_name }) => singular_name,
-  shortName: ({ singular_name_short }) => singular_name_short
-};
-
-export default PlayerPositionData;

--- a/src/resolvers/typeResolvers/index.js
+++ b/src/resolvers/typeResolvers/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 export { default as PlayerData } from './PlayerData';
-export { default as PlayerPositionData } from './PlayerPositionData';
 export { default as TeamData } from './TeamData';
 export { default as SortOption } from './SortOption';
+export { default as FilterValue } from './FilterValue';
+export { default as FilterKey } from './FilterKey';

--- a/src/utils/filterPlayers.js
+++ b/src/utils/filterPlayers.js
@@ -3,6 +3,10 @@ const filterPlayers = (players, filter) => {
     return players;
   }
 
+  if (filter.limit) {
+    return players.filter(player => player[filter.key] <= filter.limit);
+  }
+
   return players.filter(player => player[filter.key] === filter.value);
 };
 

--- a/src/utils/filterPlayers.js
+++ b/src/utils/filterPlayers.js
@@ -1,0 +1,9 @@
+const filterPlayers = (players, filter) => {
+  if (!filter) {
+    return players;
+  }
+
+  return players.filter(player => player[filter.key] === filter.value);
+};
+
+export default filterPlayers;


### PR DESCRIPTION
Add filtering on search results, currently on on `TEAM`, `POSITION` and ` VALUE`

Moved position data from a type resolver to be the parent resolver, this to me made more sense than having it further down, it also made it easier to do filtering.

